### PR TITLE
Change badges storage to a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ npm run verify:mumbai -- <smart contract address>
 
 ## Deployed contract for testing
 
-The current contract is deployed on the Mumbai testnet here: [0x167C29c76Fcf0ac7EF29FccfaB25a763fEEb4707](https://mumbai.polygonscan.com/address/0x167C29c76Fcf0ac7EF29FccfaB25a763fEEb4707)
+The current contract is deployed on the Mumbai testnet here: [0x35b5147E74993fD8B77c859d5489A22BFB21e015](https://mumbai.polygonscan.com/address/0x35b5147E74993fD8B77c859d5489A22BFB21e015)

--- a/assets/html/nft.html
+++ b/assets/html/nft.html
@@ -13,11 +13,8 @@
             This NFT represents an on-chain proof of the owners achievements on
             <a href="https://github.com/underfitted/bnomial" target="_blank">Bnomial</a>
         </p>
-        <img
-            id="badge-image"
-            src="https://gateway.pinata.cloud/ipfs/QmfFSMhxwq4JESi3179nK54ydhUbrpAxDwaDJMUHC253tg/3.png"
-            width="100px"
-        />
+
+        <h3 id="badges"></h3>
 
         <script src="nft.js"></script>
     </body>

--- a/assets/html/nft.js
+++ b/assets/html/nft.js
@@ -1,10 +1,8 @@
 function init() {
     const urlParams = new URLSearchParams(window.location.search);
-    const level = urlParams.get("level");
+    const badges = urlParams.get("badges");
 
-    document.getElementById(
-        "badge-image"
-    ).src = `https://gateway.pinata.cloud/ipfs/QmfFSMhxwq4JESi3179nK54ydhUbrpAxDwaDJMUHC253tg/${level}.png`;
+    document.getElementById("badges").innerHTML = badges;
 }
 
 window.addEventListener("load", init);

--- a/contracts/BnomialNFT.sol
+++ b/contracts/BnomialNFT.sol
@@ -36,10 +36,6 @@ contract BnomialNFT is ERC721, Ownable {
         _badges[owner].push(badge);
     }
 
-    // function getBadge(address to) public view returns (uint256) {
-    //     return _levels[to];
-    // }
-
     function getBadges(address owner) public view returns (uint256[] memory) {
         return _badges[owner];
     }

--- a/contracts/BnomialNFT.sol
+++ b/contracts/BnomialNFT.sol
@@ -62,7 +62,7 @@ contract BnomialNFT is ERC721, Ownable {
         string memory badgesString = "";
         for (uint256 i = 0; i < badges.length; i++) {
             badgesString = string(
-                abi.encodePacked(badgesString, Strings.toString(badges[i]))
+                abi.encodePacked(badgesString, Strings.toString(badges[i]), ",")
             );
         }
 

--- a/contracts/BnomialNFT.sol
+++ b/contracts/BnomialNFT.sol
@@ -12,32 +12,36 @@ contract BnomialNFT is ERC721, Ownable {
 
     Counters.Counter private _tokenIdCounter;
 
-    mapping(address => uint256) private _levels;
+    mapping(address => uint256[]) private _badges;
 
     constructor() ERC721("Bnomial Achievement Badge", "BNOMIAL") {}
 
     function _baseURI() internal pure override returns (string memory) {
-        return "ipfs://QmUE45oBmtMweg6skYBj21navRCgPs29q6p9oSmeYMAUqt/";
+        return "ipfs://QmacF9yRXkUEUHvJuCCC77JhzSLMWWJ8vFciTeVfzEoByf/";
     }
 
     function totalSupply() public view returns (uint256) {
         return _tokenIdCounter.current();
     }
 
-    function mintBadge(address to, uint256 level) external onlyOwner {
+    function mint(address to, uint256 badge) external onlyOwner {
         require(balanceOf(to) == 0, "Only one token per wallet allowed");
 
         _tokenIdCounter.increment();
         _safeMint(to, _tokenIdCounter.current());
-        _levels[to] = level;
+        addBadge(to, badge);
     }
 
-    function setLevel(address to, uint256 level) external onlyOwner {
-        _levels[to] = level;
+    function addBadge(address owner, uint256 badge) public onlyOwner {
+        _badges[owner].push(badge);
     }
 
-    function getLevel(address to) public view returns (uint256) {
-        return _levels[to];
+    // function getBadge(address to) public view returns (uint256) {
+    //     return _levels[to];
+    // }
+
+    function getBadges(address owner) public view returns (uint256[] memory) {
+        return _badges[owner];
     }
 
     function tokenURI(uint256 tokenId)
@@ -53,7 +57,14 @@ contract BnomialNFT is ERC721, Ownable {
         );
 
         address owner = ownerOf(tokenId);
-        uint256 level = _levels[owner];
+        uint256[] memory badges = _badges[owner];
+
+        string memory badgesString = "";
+        for (uint256 i = 0; i < badges.length; i++) {
+            badgesString = string(
+                abi.encodePacked(badgesString, Strings.toString(badges[i]))
+            );
+        }
 
         string memory part0 = '{"name":"Bnomial Badges",';
         string
@@ -63,8 +74,8 @@ contract BnomialNFT is ERC721, Ownable {
         string memory part4 = 'nft.png",';
         string memory part5 = '"animation_url":"';
         string memory part6 = _baseURI();
-        string memory part7 = "nft.html?level=";
-        string memory part8 = Strings.toString(level);
+        string memory part7 = "nft.html?badges=";
+        string memory part8 = badgesString;
         string memory part9 = '"}';
 
         string memory json = Base64.encode(

--- a/test/BnomialNFT.test.js
+++ b/test/BnomialNFT.test.js
@@ -95,11 +95,12 @@ describe("BnomialNFT", () => {
 
     it("should return a JSON metadata", async () => {
         const metadataJson =
-            '{"name":"Bnomial Badges","description":"This NFT represents an on-chain proof of the owners achievements on Bnomial","image":"ipfs://QmacF9yRXkUEUHvJuCCC77JhzSLMWWJ8vFciTeVfzEoByf/nft.png","animation_url":"ipfs://QmacF9yRXkUEUHvJuCCC77JhzSLMWWJ8vFciTeVfzEoByf/nft.html?badges=2"}';
+            '{"name":"Bnomial Badges","description":"This NFT represents an on-chain proof of the owners achievements on Bnomial","image":"ipfs://QmacF9yRXkUEUHvJuCCC77JhzSLMWWJ8vFciTeVfzEoByf/nft.png","animation_url":"ipfs://QmacF9yRXkUEUHvJuCCC77JhzSLMWWJ8vFciTeVfzEoByf/nft.html?badges=2,20,"}';
         const expectedMetadata = "data:application/json;base64," + Buffer.from(metadataJson).toString("base64");
 
-        // Mint a badge
+        // Mint a badge and add another one
         await contract.mint(addr1.address, 2);
+        await contract.addBadge(addr1.address, 20);
 
         // Expect the returned metadata to be correct
         expect(await contract.tokenURI(1)).to.equal(expectedMetadata);

--- a/test/BnomialNFT.test.js
+++ b/test/BnomialNFT.test.js
@@ -16,7 +16,7 @@ describe("BnomialNFT", () => {
 
     it("should mint a badge", async () => {
         // Mint a badge
-        await contract.mintBadge(addr1.address, 1);
+        await contract.mint(addr1.address, 1);
 
         expect(await contract.totalSupply()).to.equal(1);
         expect(await contract.balanceOf(addr1.address)).to.equal(1);
@@ -25,17 +25,17 @@ describe("BnomialNFT", () => {
 
     it("should allow only owner to mint a badge", async () => {
         // Expect minting from another wallet to fail
-        await expect(contract.connect(addr1).mintBadge(addr1.address, 1)).to.be.revertedWith(
+        await expect(contract.connect(addr1).mint(addr1.address, 1)).to.be.revertedWith(
             "VM Exception while processing transaction: reverted with reason string 'Ownable: caller is not the owner'"
         );
 
         // Expect minting from owner to succeed
-        await contract.mintBadge(addr1.address, 1);
+        await contract.mint(addr1.address, 1);
     });
 
     it("should start counting tokens from 1", async () => {
         // Mint a badge
-        await contract.mintBadge(addr1.address, 1);
+        await contract.mint(addr1.address, 1);
 
         // Expect getting the owner of token 0 to fail
         await expect(contract.ownerOf(0)).to.be.revertedWith(
@@ -46,60 +46,60 @@ describe("BnomialNFT", () => {
         await expect(contract.ownerOf(1)).to.not.be.reverted;
     });
 
-    it("should set the level when minting", async () => {
+    it("should set the badge when minting", async () => {
         // Mint a badge
-        await contract.mintBadge(addr1.address, 2);
+        await contract.mint(addr1.address, 1);
 
-        expect(await contract.getLevel(addr1.address)).to.equal(2);
+        expect(await contract.getBadges(addr1.address)).to.deep.equal([BigNumber.from(1)]);
     });
 
-    it("should get level", async () => {
-        // Get the level for unassigned wallet
-        expect(await contract.getLevel(addr1.address)).to.equal(0);
+    it("should get badges", async () => {
+        // Get the badges for unassigned wallet
+        expect(await contract.getBadges(addr1.address)).to.deep.equal([]);
     });
 
-    it("should set level", async () => {
+    it("should add badge", async () => {
         // Mint a badge
-        await contract.mintBadge(addr1.address, 2);
+        await contract.mint(addr1.address, 1);
 
-        // Expect the level to be 2
-        expect(await contract.getLevel(addr1.address)).to.equal(2);
+        // Expect the badges to contain only 1
+        expect(await contract.getBadges(addr1.address)).to.deep.equal([BigNumber.from(1)]);
 
-        // Change the level
-        await contract.setLevel(addr1.address, 3);
+        // Add a new badge
+        await contract.addBadge(addr1.address, 2);
 
-        // Expect the level to be 3
-        expect(await contract.getLevel(addr1.address)).to.equal(3);
+        // Expect the badges to be [1, 2]
+        expect(await contract.getBadges(addr1.address)).to.deep.equal([BigNumber.from(1), BigNumber.from(2)]);
     });
 
-    it("should set level for a wallet that has no badge", async () => {
-        // Expect the level to be 0
-        expect(await contract.getLevel(addr1.address)).to.equal(0);
+    it("should add badge for a wallet that has no badges", async () => {
+        // Expect the badges to be empty
+        expect(await contract.getBadges(addr1.address)).to.deep.equal([]);
 
-        // Change the level
-        await contract.setLevel(addr1.address, 3);
+        // Add a badge
+        await contract.addBadge(addr1.address, 1);
 
-        // Expect the level to be 3
-        expect(await contract.getLevel(addr1.address)).to.equal(3);
+        // Expect the badges to be [1]
+        expect(await contract.getBadges(addr1.address)).to.deep.equal([BigNumber.from(1)]);
     });
 
-    it("should allow only owner to set level", async () => {
+    it("should allow only owner to add badges", async () => {
         // Expect minting from another wallet to fail
-        await expect(contract.connect(addr1).setLevel(addr1.address, 1)).to.be.revertedWith(
+        await expect(contract.connect(addr1).addBadge(addr1.address, 1)).to.be.revertedWith(
             "VM Exception while processing transaction: reverted with reason string 'Ownable: caller is not the owner'"
         );
 
         // Expect minting from owner to succeed
-        await contract.setLevel(addr1.address, 1);
+        await contract.addBadge(addr1.address, 1);
     });
 
     it("should return a JSON metadata", async () => {
         const metadataJson =
-            '{"name":"Bnomial Badges","description":"This NFT represents an on-chain proof of the owners achievements on Bnomial","image":"ipfs://QmUE45oBmtMweg6skYBj21navRCgPs29q6p9oSmeYMAUqt/nft.png","animation_url":"ipfs://QmUE45oBmtMweg6skYBj21navRCgPs29q6p9oSmeYMAUqt/nft.html?level=2"}';
+            '{"name":"Bnomial Badges","description":"This NFT represents an on-chain proof of the owners achievements on Bnomial","image":"ipfs://QmacF9yRXkUEUHvJuCCC77JhzSLMWWJ8vFciTeVfzEoByf/nft.png","animation_url":"ipfs://QmacF9yRXkUEUHvJuCCC77JhzSLMWWJ8vFciTeVfzEoByf/nft.html?badges=2"}';
         const expectedMetadata = "data:application/json;base64," + Buffer.from(metadataJson).toString("base64");
 
         // Mint a badge
-        await contract.mintBadge(addr1.address, 2);
+        await contract.mint(addr1.address, 2);
 
         // Expect the returned metadata to be correct
         expect(await contract.tokenURI(1)).to.equal(expectedMetadata);
@@ -113,20 +113,20 @@ describe("BnomialNFT", () => {
 
     it("should allow only one token per non-owner wallet", async () => {
         // Minting one badge should work
-        await contract.mintBadge(addr1.address, 2);
+        await contract.mint(addr1.address, 2);
 
         // Minting another tokenfor the same wallet should fail
-        await expect(contract.mintBadge(addr1.address, 3)).to.be.revertedWith(
+        await expect(contract.mint(addr1.address, 3)).to.be.revertedWith(
             "VM Exception while processing transaction: reverted with reason string 'Only one token per wallet allowed'"
         );
     });
 
     it("should block nft transfer", async () => {
         // Minting one badge for owner wallet
-        await contract.mintBadge(owner.address, 1);
+        await contract.mint(owner.address, 1);
 
         // transfer nft from owner wallet should fail
-        await expect(contract.transferFrom(owner.address,addr1.address, 1)).to.be.revertedWith(
+        await expect(contract.transferFrom(owner.address, addr1.address, 1)).to.be.revertedWith(
             "ERC721: token transfer disabled"
         );
     });


### PR DESCRIPTION
This PR changes the way that badges (before levels) are stored on the blockchain. Now, every wallet is mapped to a list containing all the badges the wallet has earned.

Resolves: #2 