### PR TITLE
Allow_users_to_mint

### DIFF
--- a/contracts/BnomialNFT.sol
+++ b/contracts/BnomialNFT.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
 import "./Base64.sol";
+import "hardhat/console.sol";
 
 contract BnomialNFT is ERC721, Ownable {
     using Counters for Counters.Counter;
@@ -24,12 +25,15 @@ contract BnomialNFT is ERC721, Ownable {
         return _tokenIdCounter.current();
     }
 
-    function mint(address to, uint256 badge) external onlyOwner {
+    function mint(address to) external {
         require(balanceOf(to) == 0, "Only one token per wallet allowed");
+        require(_badges[to].length > 0, "At least one achievement is needed");
+        _tokenIdCounter.increment();      
+        _safeMint(to, _tokenIdCounter.current());       
+    }
 
-        _tokenIdCounter.increment();
-        _safeMint(to, _tokenIdCounter.current());
-        addBadge(to, badge);
+    function canMint(address owner) public view returns (bool) {
+        return (_badges[owner].length > 0) ? true : false;
     }
 
     function addBadge(address owner, uint256 badge) public onlyOwner {

--- a/contracts/BnomialNFT.sol
+++ b/contracts/BnomialNFT.sol
@@ -28,12 +28,13 @@ contract BnomialNFT is ERC721, Ownable {
     function mint(address to) external {
         require(balanceOf(to) == 0, "Only one token per wallet allowed");
         require(_badges[to].length > 0, "At least one achievement is needed");
+        require(msg.sender == owner() || msg.sender == to, "Only contract's owner or token's owner are allowed to mint");
         _tokenIdCounter.increment();      
         _safeMint(to, _tokenIdCounter.current());       
     }
 
     function canMint(address owner) public view returns (bool) {
-        return (_badges[owner].length > 0) ? true : false;
+        return (_badges[owner].length > 0);
     }
 
     function addBadge(address owner, uint256 badge) public onlyOwner {


### PR DESCRIPTION
The following was implemented:

Allow all wallets to call the minting function
Block the transaction for wallets that have no achievement stored on chain
Implement a function that tells if a wallet is allowed to mint
Implement tests with 100% coverage
Deploy on the Mumbai testnet