### PR TITLE
Add vscode remote

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -2,19 +2,8 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/javascript-node
 {
 	"name": "bnomial-web3-dev",
-	// "build": {
-	// 	"context": "..",
-	// 	"dockerfile": "Dockerfile",
-	// 	// Update 'VARIANT' to pick a Node version: 16, 14, 12.
-	// 	// Append -bullseye or -buster to pin to an OS version.
-	// 	// Use -bullseye variants on local arm64/Apple Silicon.
-	// 	"args": { "VARIANT": "16-bullseye", "WRKSPC": "${containerWorkspaceFolder}"}
-	// },
 	
 	"image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:0-16-bullseye",
-
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
 
 	"workspaceMount": "source=${localWorkspaceFolder},target=/underfitted/bnomial-web3,type=bind,consistency=cached",
 	"workspaceFolder": "/underfitted/bnomial-web3",
@@ -23,9 +12,6 @@
 	"extensions": [
 		"juanblanco.solidity"
 	],
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "npm install",

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/javascript-node
+{
+	"name": "bnomial-web3-dev",
+	// "build": {
+	// 	"context": "..",
+	// 	"dockerfile": "Dockerfile",
+	// 	// Update 'VARIANT' to pick a Node version: 16, 14, 12.
+	// 	// Append -bullseye or -buster to pin to an OS version.
+	// 	// Use -bullseye variants on local arm64/Apple Silicon.
+	// 	"args": { "VARIANT": "16-bullseye", "WRKSPC": "${containerWorkspaceFolder}"}
+	// },
+	
+	"image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:0-16-bullseye",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+	"workspaceMount": "source=${localWorkspaceFolder},target=/underfitted/bnomial-web3,type=bind,consistency=cached",
+	"workspaceFolder": "/underfitted/bnomial-web3",
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"juanblanco.solidity"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "npm install",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node"
+}

--- a/README.md
+++ b/README.md
@@ -2,24 +2,59 @@
 
 Smart contracts for [bnomial](https://github.com/underfitted/bnomial).
 
+## Repository Organization
+
+The main artifacts (files and folders) in the repository are:
+
+- [contracts](contracts/): It contains smart contracts, NFTs and related utility functions for the project;
+- [scripts](scripts/): [Hardhat](https://hardhat.org/) custom scripts;
+- [test](test/): Bnomial test sets;
+- [hardhat.config.js](hardhat.config.js): Main configuration file for Hardhat. You should customize it if you want to deploy
+the contracts in remote networks.
+
 ## Setup
 
-To setup your environment:
+### Local machine \ IDE agnostic
+
+You should have [npm](https://www.npmjs.com/) installed, so be sure to follow the proper procedure for your OS. After that, download and install all required libraries and plugins by running:
 
 ```
 npm install
 ```
 
-To setup your API keys and private keys create an `.env` file with the following content (the `POLYGON_API_URL` is not needed if you are just testing on Mumbai).
+### VSCode Remote Container
 
-```
-MUMBAI_API_URL="<Alachemy HTTP URL>"
-POLYGON_API_URL="<Alachemy HTTP URL>"
-PRIVATE_KEY="<deploy wallet private key>"
-POLYSCAN_KEY="<Ploygonscan API key for verification>"
-```
+You may use [VSCode Remote Container](https://code.visualstudio.com/docs/remote/containers) if you want to avoid local
+installations. Just install the extension and setup your local Docker as described 
+[here](https://code.visualstudio.com/docs/remote/containers#_getting-started).
+
+When running the project in the development container, you may use the embedded vscode terminal to execute the 
+_deployment workflow_.
+
+> :warning: The container runs all processes and update the files as the internal user _node:node_ (1000:1000).
 
 ## Develop
+
+Smart contracts and NFTs demand an account and a blockchain network to be deployed into. Besides that, it's important to set an
+access provider (e.g., [Alchemy](https://www.alchemy.com/) or [Infura](https://infura.io/)) and a blockchain explorer 
+(e.g. [Polygonscan](https://polygonscan.com/) or [Etherscan](https://etherscan.io/)). Hardhat provides a built-in network to 
+ease local development. When deploying to remote networks, you must:
+
+- Set up [hardhat configuration file](hardhat.config.js) by removing the comments according to the network you want to use;
+- Create an `.env` file and set up the required information for the network (the `POLYGON_API_URL` is not needed if you are 
+just testing on Mumbai). The properties are:
+    - `MUMBAI_API_URL`: Alchemy HTTP URL
+    - `POLYGON_API_URL`: Alchemy HTTP URL
+    - `PRIVATE_KEY` : Deploy wallet private key
+    - `POLYSCAN_KEY` : Polygonscan API key for verification 
+
+Here is an example of `.env`file for deploying a contract in Mumbai Net:
+
+```
+MUMBAI_API_URL="https://polygon-mumbai.g.alchemy.com/v2/ThIs0Is1NoT2a3VaLiD4aPi5KeY99999"
+PRIVATE_KEY="1A2LoNg3BoRiNg4AnD5FAke6PriVATE7KEY8FOR9MumBAI10NETwork000999111"
+POLYSCAN_KEY="0ANOTHER111FAKE22222KEY3333333HERE"
+```
 
 The smart contract code is in [contracts/BnomialNFT.sol](/contracts/BnomialNFT.sol).
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ To compile it run:
 npm run build
 ```
 
+Detailed description of Bnomial project and some guidelines regarding its set up and development is available in the [official documentation](https://docs.underfitted.io/incubator/bnomial/web3/environment-setup).
+
 ## Test
 
 The tests for the smart contract are in [test/BnomialNFT.test.js](/test/BnomialNFT.test.js).

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Smart contracts for [bnomial](https://github.com/underfitted/bnomial).
 
 The main artifacts (files and folders) in the repository are:
 
-- [contracts](contracts/): It contains smart contracts, NFTs and related utility functions for the project;
-- [scripts](scripts/): [Hardhat](https://hardhat.org/) custom scripts;
-- [test](test/): Bnomial test sets;
-- [hardhat.config.js](hardhat.config.js): Main configuration file for Hardhat. You should customize it if you want to deploy
-the contracts in remote networks.
+-   [contracts](contracts/): It contains smart contracts, NFTs and related utility functions for the project;
+-   [scripts](scripts/): [Hardhat](https://hardhat.org/) custom scripts;
+-   [test](test/): Bnomial test sets;
+-   [hardhat.config.js](hardhat.config.js): Main configuration file for Hardhat. You should customize it if you want to deploy
+    the contracts in remote networks.
 
 ## Setup
 
@@ -25,10 +25,10 @@ npm install
 ### VSCode Remote Container
 
 You may use [VSCode Remote Container](https://code.visualstudio.com/docs/remote/containers) if you want to avoid local
-installations. Just install the extension and setup your local Docker as described 
+installations. Just install the [extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) and setup your local Docker as described
 [here](https://code.visualstudio.com/docs/remote/containers#_getting-started).
 
-When running the project in the development container, you may use the embedded vscode terminal to execute the 
+When running the project in the development container, you may use the embedded vscode terminal to execute the
 _deployment workflow_.
 
 > :warning: The container runs all processes and update the files as the internal user _node:node_ (1000:1000).
@@ -36,17 +36,13 @@ _deployment workflow_.
 ## Develop
 
 Smart contracts and NFTs demand an account and a blockchain network to be deployed into. Besides that, it's important to set an
-access provider (e.g., [Alchemy](https://www.alchemy.com/) or [Infura](https://infura.io/)) and a blockchain explorer 
-(e.g. [Polygonscan](https://polygonscan.com/) or [Etherscan](https://etherscan.io/)). Hardhat provides a built-in network to 
+access provider (e.g., [Alchemy](https://www.alchemy.com/) or [Infura](https://infura.io/)) and a blockchain explorer
+(e.g. [Polygonscan](https://polygonscan.com/) or [Etherscan](https://etherscan.io/)). Hardhat provides a built-in network to
 ease local development. When deploying to remote networks, you must:
 
-- Set up [hardhat configuration file](hardhat.config.js) by removing the comments according to the network you want to use;
-- Create an `.env` file and set up the required information for the network (the `POLYGON_API_URL` is not needed if you are 
-just testing on Mumbai). The properties are:
-    - `MUMBAI_API_URL`: Alchemy HTTP URL
-    - `POLYGON_API_URL`: Alchemy HTTP URL
-    - `PRIVATE_KEY` : Deploy wallet private key
-    - `POLYSCAN_KEY` : Polygonscan API key for verification 
+-   Set up [hardhat configuration file](hardhat.config.js) by removing the comments according to the network you want to use;
+-   Create an `.env` file and set up the required information for the network (the `POLYGON_API_URL` is not needed if you are
+    just testing on Mumbai). The properties are: - `MUMBAI_API_URL`: Alchemy HTTP URL - `POLYGON_API_URL`: Alchemy HTTP URL - `PRIVATE_KEY` : Deploy wallet private key - `POLYSCAN_KEY` : Polygonscan API key for verification
 
 Here is an example of `.env`file for deploying a contract in Mumbai Net:
 
@@ -111,4 +107,3 @@ npm run verify:mumbai -- <smart contract address>
 The current NFT contract is deployed on the Mumbai testnet here: [0x35b5147E74993fD8B77c859d5489A22BFB21e015](https://mumbai.polygonscan.com/address/0x35b5147E74993fD8B77c859d5489A22BFB21e015)
 
 The current Token contract is deployed on the Mumbai testnet here: [0xc4C99f33F686A74a2Fe95B26Ce317708f605A9eA](https://mumbai.polygonscan.com/address/0xc4C99f33F686A74a2Fe95B26Ce317708f605A9eA)
-

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -10,14 +10,15 @@ module.exports = {
     solidity: "0.8.2",
     networks: {
         hardhat: {},
-        mumbai: {
-            url: MUMBAI_API_URL,
-            accounts: [`0x${PRIVATE_KEY}`],
-        },
-        polygon: {
-            url: POLYGON_API_URL,
-            accounts: [`0x${PRIVATE_KEY}`],
-        },
+        // Uncomment according to the network you wanna use
+        // mumbai: {
+        //     url: MUMBAI_API_URL,
+        //     accounts: [`0x${PRIVATE_KEY}`],
+        // },
+        // polygon: {
+        //     url: POLYGON_API_URL,
+        //     accounts: [`0x${PRIVATE_KEY}`],
+        // },
     },
     etherscan: {
         apiKey: POLYSCAN_KEY,

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -4,21 +4,23 @@ require("hardhat-gas-reporter");
 require("solidity-coverage");
 require("dotenv").config();
 
-const { MUMBAI_API_URL, POLYGON_API_URL, PRIVATE_KEY, POLYSCAN_KEY } = process.env;
+const MUMBAI_API_URL = process.env.MUMBAI_API_URL || "";
+const POLYGON_API_URL = process.env.POLYGON_API_URL || "";
+const PRIVATE_KEY = process.env.PRIVATE_KEY || "0000000000000000000000000000000000000000000000000000000000000000";
+const POLYSCAN_KEY = process.env.POLYSCAN_KEY || "";
 
 module.exports = {
     solidity: "0.8.2",
     networks: {
         hardhat: {},
-        // Uncomment according to the network you wanna use
-        // mumbai: {
-        //     url: MUMBAI_API_URL,
-        //     accounts: [`0x${PRIVATE_KEY}`],
-        // },
-        // polygon: {
-        //     url: POLYGON_API_URL,
-        //     accounts: [`0x${PRIVATE_KEY}`],
-        // },
+        mumbai: {
+            url: MUMBAI_API_URL,
+            accounts: [`0x${PRIVATE_KEY}`],
+        },
+        polygon: {
+            url: POLYGON_API_URL,
+            accounts: [`0x${PRIVATE_KEY}`],
+        },
     },
     etherscan: {
         apiKey: POLYSCAN_KEY,


### PR DESCRIPTION
This provides means for using vscode remote development extension. I'm using the default node image provided by vscode \ ms (no Dockerfile needed) . Besides the configuration file (.devcontainer.json), the changes are:

- Commented out all networks at harhat.config.js. This way `npm run build` works out of the box with hardhat local network and there is no complain about misconfigurations;
- Updated README with information about vscode remote extension and also explaining how to configure other networks besides hardhat's built-in.

I've tested vscode remote setup at Linux and Win11. Both worked OK.   