### PR TITLE
Remove the default .env file from the CI

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -28,14 +28,6 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: ${{ matrix.node-version }}
-            - name: Create env file
-              run: |
-                  cat << EOF > .env
-                  MUMBAI_API_URL=""
-                  POLYGON_API_URL=""
-                  PRIVATE_KEY="0000000000000000000000000000000000000000000000000000000000000000"
-                  POLYSCAN_KEY=""
-                  EOF
             - run: npm install
             - run: npm run build
             - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
The hardhat config now has defaults that allow all local jobs to be run without needing to specify any environment variables.