### PR TITLE
Remove the default .env file from the CI (test)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,14 +25,6 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: ${{ matrix.node-version }}
-            - name: Create env file
-              run: |
-                  cat << EOF > .env
-                  MUMBAI_API_URL=""
-                  POLYGON_API_URL=""
-                  PRIVATE_KEY="0000000000000000000000000000000000000000000000000000000000000000"
-                  POLYSCAN_KEY=""
-                  EOF
             - run: npm install
             - run: npm run build
             - run: npm run test


### PR DESCRIPTION
The hardhat config now has defaults that allow all local jobs to be run