### PR TITLE
Refactor and document the token contract

### DIFF
--- a/contracts/BnomialToken .sol
+++ b/contracts/BnomialToken .sol
@@ -1,41 +1,30 @@
 // SPDX-License-Identifier: MIT
+
+/**
+ *   @title Bnomial ERC20 token contract
+ *   @author Underfitted Social Club
+ *   @notice ERC20 smart contract for the Bnomial token. The token is inflationary since new tokens will be minted after every season.
+ */
+
 pragma solidity ^0.8.2;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
-import "@openzeppelin/contracts/security/Pausable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract BnomialToken is ERC20, ERC20Burnable, Pausable, Ownable {
+contract BnomialToken is ERC20, ERC20Burnable, Ownable {
+    /**
+     * @dev Default constructor
+     */
     constructor() ERC20("Bnomial Token", "BNO") {}
 
-    function pause() external onlyOwner {
-        _pause();
-    }
-
-    function unpause() external onlyOwner {
-        _unpause();
-    }
-
+    /**
+     * @notice Only the contract owner is allowed to mint new tokens
+     * @dev Mint new tokens to a specified address
+     * @param to The address to mint tokens to
+     * @param amount The amount of tokens to mint
+     */
     function mint(address to, uint256 amount) external onlyOwner {
         super._mint(to, amount);
-    }
-
-    function _beforeTokenTransfer(
-        address from,
-        address to,
-        uint256 amount
-    ) internal override whenNotPaused {
-        super._beforeTokenTransfer(from, to, amount);
-    }
-
-    // The following functions are overrides required by Solidity.
-
-    function _afterTokenTransfer(
-        address from,
-        address to,
-        uint256 amount
-    ) internal override(ERC20) {
-        super._afterTokenTransfer(from, to, amount);
     }
 }


### PR DESCRIPTION
This PR refactors the token contract and its tests and documents it.

It also drops the support for pausing and unpausing the contract.