### PR TITLE
Add function to set the base URI

### DIFF
--- a/contracts/BnomialNFT.sol
+++ b/contracts/BnomialNFT.sol
@@ -17,6 +17,7 @@ import "./Base64.sol";
 contract BnomialNFT is ERC721, Ownable {
     using Counters for Counters.Counter;
 
+    string public baseURI = "ipfs://QmacF9yRXkUEUHvJuCCC77JhzSLMWWJ8vFciTeVfzEoByf/";
     Counters.Counter private _tokenIdCounter;
     mapping(address => uint256[]) private _badges;
 
@@ -26,11 +27,19 @@ contract BnomialNFT is ERC721, Ownable {
     constructor() ERC721("Bnomial Achievement Badge", "BNOMIAL") {}
 
     /**
-     * @dev Defines the base URI for the tokens
+     * @dev Get the base URI for the tokens
      * @return string representing the base URI
      */
-    function _baseURI() internal pure override returns (string memory) {
-        return "ipfs://QmacF9yRXkUEUHvJuCCC77JhzSLMWWJ8vFciTeVfzEoByf/";
+    function _baseURI() internal view override returns (string memory) {
+        return baseURI;
+    }
+
+    /**
+     * @dev Set the base URI for the tokens
+     * @param uri new base URI
+     */
+    function setBaseURI(string memory uri) external onlyOwner {
+        baseURI = uri;
     }
 
     /**

--- a/test/BnomialNFT.test.js
+++ b/test/BnomialNFT.test.js
@@ -15,6 +15,22 @@ describe("BnomialNFT", () => {
         contract = await BnomialNFTContract.deploy()
     })
 
+    it("should change the base URI", async () => {
+        // Change the base URI and check
+        await contract.setBaseURI("ipfs://testuri")
+        expect(await contract.baseURI()).to.equal("ipfs://testuri")
+    })
+
+    it("should allow only owner to set the base URI", async () => {
+        // Expect setting the URI from another wallet to fail
+        await expect(contract.connect(addr1).setBaseURI("ipfs://testuri")).to.be.revertedWith(
+            "VM Exception while processing transaction: reverted with reason string 'Ownable: caller is not the owner'"
+        )
+
+        // Expect setting the URI from owner to succeed
+        await expect(contract.setBaseURI("ipfs://testuri")).to.not.be.reverted
+    })
+
     it("should allow mint only if the address has a badge assigned", async () => {
         // Add a badge and mint
         await contract.addBadge(addr1.address, 1)


### PR DESCRIPTION
This PR allows the base URI in the smart contract to be set after creation.

Resolves: #9 